### PR TITLE
added id property to GridFSBucketWriteStream

### DIFF
--- a/mongodb.d.ts
+++ b/mongodb.d.ts
@@ -1341,4 +1341,6 @@ export interface GridFSBucketFindOptions {
 export interface GridFSBucketReadStream extends Readable {}
 
 // http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucketWriteStream.html
-export interface GridFSBucketWriteStream extends Writable {}
+export interface GridFSBucketWriteStream extends Writable {
+    id: ObjectID;
+}


### PR DESCRIPTION
This one is pretty straightforward. From the example on [openUploadStream](http://mongodb.github.io/node-mongodb-native/2.1/api/GridFSBucket.html#openUploadStream)

```
    var uploadStream = bucket.openUploadStream('test.dat');
    var id = uploadStream.id;
```
